### PR TITLE
Fixed error of using wrong variable to set cutoff for min number of genes for a prophage

### DIFF
--- a/modules/evaluation.py
+++ b/modules/evaluation.py
@@ -314,7 +314,7 @@ def fixing_start_end(**kwargs): #output_dir, organism_path, INSTALLATION_DIR, ph
     j = 1
     prophagesummary = []
     for i in pp:
-        if pp[i]['num genes'] >= self.window_size:
+        if pp[i]['num genes'] >= self.number:
             temppp[j] = pp[i]
             j += 1
             prophagesummary.append([pp[i]['contig'], pp[i]['start'], pp[i]['stop'], pp[i]['num genes'], "Kept"])


### PR DESCRIPTION
I am pretty sure the wrong parameter got used in [evaluation.py](https://github.com/linsalrob/PhiSpy/blob/7de1d69fbe61224d2c7c29866ea3a3b29c7ee948/modules/evaluation.py#L317) for setting the minimum number of genes required to call a region a prophage.  This was due to the previous convuloted methods of passing positional arguements throgh multiple functions; which we got rid of in favor of a single **kwargs

Subsequently we might also change the --number flag to something more descriptive, like --min_genes or soemthing. 