### PR TITLE
Specify repository in release upload command

### DIFF
--- a/.github/workflows/publish_releases.yml
+++ b/.github/workflows/publish_releases.yml
@@ -134,4 +134,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload "${{ github.event.release.tag_name }}" pyodide-wheelhouse/*.whl --clobber
+          gh release upload "${{ github.event.release.tag_name }}" pyodide-wheelhouse/*.whl \
+          --repo "${{ github.repository }}" \
+          --clobber


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow for publishing releases. The change ensures that the `gh release upload` command explicitly specifies the repository to which the release assets should be uploaded.

* Workflow improvement:
  * [`.github/workflows/publish_releases.yml`](diffhunk://#diff-bef0964523481b1147be9e02c1161b3245f3d40c9a4ed736be24617d30b69b49L137-R139): Added the `--repo "${{ github.repository }}"` flag to the `gh release upload` command to explicitly set the target repository.Update GitHub Actions workflow to specify repository in release upload command.